### PR TITLE
Added CLI option to define alternative GMS installation dir

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -34,7 +34,8 @@ const options = cli.parse({
     yyc: ["y", "Compiles with YYC"],
     config: ["c", "Sets the configuration", "string"],
     version: ["v", "Display the current version"],
-    clear: ["", "Clears cache for project and exits."]
+    clear: ["", "Clears cache for project and exits."],
+    "gms-dir":["","Alternative GMS installation directory","path"],
 });
 // CLI calls the callback with the arguments and options.
 cli.main((args, options) => {
@@ -92,6 +93,12 @@ cli.main((args, options) => {
     if (options.installer) {
         buildType = "installer";
     }
+    
+    let gamemakerLocation: string = "";
+    if (options["gms-dir"]){
+        gamemakerLocation = options["gms-dir"];
+        console.log("install dir:"+gamemakerLocation);
+    }
     // Use the api to compile the project.
     const build = rubber.windows({
         projectPath: path,
@@ -99,7 +106,8 @@ cli.main((args, options) => {
         outputPath: args[1] || "",
         yyc: options.yyc,
         config: options.config || "default",
-        verbose: options.debug
+        verbose: options.debug,
+        gamemakerLocation
     });
     build.on("compileStatus", (data:string) => {
         // Errors will be marked in red

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -97,7 +97,7 @@ cli.main((args, options) => {
     let gamemakerLocation: string = "";
     if (options["gms-dir"]){
         gamemakerLocation = options["gms-dir"];
-        console.log("install dir:"+gamemakerLocation);
+        cli.debug("install dir:"+gamemakerLocation);
     }
     // Use the api to compile the project.
     const build = rubber.windows({

--- a/src/rubber.ts
+++ b/src/rubber.ts
@@ -81,7 +81,8 @@ export function compile(options: IRubberOptions) {
         if (typeof options.gamemakerDataLocation === "undefined") {
             options.gamemakerDataLocation = "C:\\ProgramData\\GameMakerStudio2";
         }
-        if (typeof options.gamemakerLocation === "undefined") {
+
+        if (typeof options.gamemakerLocation === "undefined" || options.gamemakerLocation === ""){
             options.gamemakerLocation = "C:\\Program Files\\GameMaker Studio 2";
         }
         


### PR DESCRIPTION
Added CLI option to define alternative GMS installation dir

Users can now define their GMS installation dir. If left undefined or empty, Rubber will use the default installation dir