### PR TITLE
Added export support for iOS, Mac, and Linux

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -36,7 +36,9 @@ const options = cli.parse({
     version: ["v", "Display the current version"],
     clear: ["", "Clears cache for project and exits."],
     "gms-dir":["","Alternative GMS installation directory","path"],
-    "export-platform":["p","Export platform","string"]
+    "export-platform":["p","Export platform","string"],
+    "device-config-dir":["","Target device config file directory", "path"],
+    "target-device-name":["","Target device name","string"]
 });
 // CLI calls the callback with the arguments and options.
 cli.main((args, options) => {
@@ -95,10 +97,26 @@ cli.main((args, options) => {
         buildType = "installer";
     }
     
+    // Alternative GMS install dir
     let gamemakerLocation: string = "";
     if (options["gms-dir"]){
         gamemakerLocation = options["gms-dir"];
     }
+
+    /** 
+     * For non-Windows platform, target devices need to be provided
+     * Target device info are usually located at "C:\Users\xxx\AppData\Roaming\GameMakerStudio2\YoyoAccountName\devices.json", but I cannot figure out where to parse the YoyoAccountName, so I will let user define the path   
+    */
+    let deviceConfigFileLocation: string = "";
+    if (options["device-config-dir"]){
+        deviceConfigFileLocation = options["device-config-dir"];
+    }
+
+    // Choose a target device among the available devices. Will grab the first one if left empty
+    let targetDeviceName: string = "";
+    if (options["target-device-name"]){
+        targetDeviceName = options["target-device-name"];
+    }   
 
     let platform: "windows" | "mac" | "linux" | "ios" | "android" | "ps4" | "xboxone" | "switch" | "html5" | "uwp" = "windows";
     if (options["export-platform"]){
@@ -114,7 +132,9 @@ cli.main((args, options) => {
         config: options.config || "default",
         verbose: options.debug,
         gamemakerLocation,
-        platform
+        platform,
+        deviceConfigFileLocation,
+        targetDeviceName
     });
     build.on("compileStatus", (data:string) => {
         // Errors will be marked in red


### PR DESCRIPTION
Added export support for iOS, Mac, and Linux and the options to choose target devices for non-Windows platform by reading the `devices.json`

CLI now takes in 2 additional options:

## `--device-config-dir`

For non-Windows platform, target devices need to be provided for test runs, and for building packages for iOS, Mac, and Linux.
Target device info are usually located at `C:\Users\xxx\AppData\Roaming\GameMakerStudio2\YoyoAccountName\devices.json`, but I cannot figure out how to parse the YoyoAccountName, so I will let user define the path

## `--target-device-name`

User has to specify a device among the available ones defined in `devices.json`, or the first one will be chosen as default

## Test Results

1. Switch can build package, but running is not stable yet
2. Mac can build and run, but warns about "replacing existing signature"
3. iOS can only build packages (as expected per YoYo's documentation), but gives a bunch of non-fatal error messages
4. Android can build and run
5. Linux can build and run
6. PC can build and run
7. Only VM config is tested. YYC is not tested yet.