### PR TITLE
Feature/toggle ea and specify runtime

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -107,7 +107,9 @@ cli.main((args, options) => {
 
     /** 
      * For non-Windows platform, target devices need to be provided
-     * Target device info are usually located at "C:\Users\xxx\AppData\Roaming\GameMakerStudio2\YoyoAccountName\devices.json", but I cannot figure out where to parse the YoyoAccountName, so I will let user define the path   
+     * !!! Target device info are usually located at "C:\Users\xxx\AppData\Roaming\GameMakerStudio2\YoyoAccountName\devices.json"
+     * YoyoAccountName needs to be parsed by looking into um.json file and combine the local-part of the user's email address and
+     * the userID. For now, we will just let user define that path
     */
     let deviceConfigFileLocation: string = "";
     if (options["device-config-dir"]){

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -38,7 +38,8 @@ const options = cli.parse({
     "gms-dir":["","Alternative GMS installation directory","path"],
     "export-platform":["p","Export platform","string"],
     "device-config-dir":["","Target device config file directory", "path"],
-    "target-device-name":["","Target device name","string"]
+    "target-device-name":["","Target device name","string"],
+    "runtime":["","The runtime to use","string"]
 });
 // CLI calls the callback with the arguments and options.
 cli.main((args, options) => {
@@ -123,6 +124,11 @@ cli.main((args, options) => {
         platform = options["export-platform"];
     }
 
+    let theRuntime: string = "";
+    if (options["runtime"]){
+        theRuntime = options["runtime"];
+    }
+
     // Use the api to compile the project.
     const build = rubber.compile({
         projectPath: path,
@@ -134,7 +140,8 @@ cli.main((args, options) => {
         gamemakerLocation,
         platform,
         deviceConfigFileLocation,
-        targetDeviceName
+        targetDeviceName,
+        theRuntime
     });
     build.on("compileStatus", (data:string) => {
         // Errors will be marked in red

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -39,7 +39,8 @@ const options = cli.parse({
     "export-platform":["p","Export platform","string"],
     "device-config-dir":["","Target device config file directory", "path"],
     "target-device-name":["","Target device name","string"],
-    "runtime":["","The runtime to use","string"]
+    "runtime":["","The runtime to use","string"],
+    "ea":["","Toggle whether to use Early Access version"]
 });
 // CLI calls the callback with the arguments and options.
 cli.main((args, options) => {
@@ -141,7 +142,8 @@ cli.main((args, options) => {
         platform,
         deviceConfigFileLocation,
         targetDeviceName,
-        theRuntime
+        theRuntime,
+        ea: options.ea
     });
     build.on("compileStatus", (data:string) => {
         // Errors will be marked in red

--- a/src/rubber.ts
+++ b/src/rubber.ts
@@ -35,6 +35,10 @@ export interface IRubberOptions {
 
     /** Alternate Runtime Location */
     runtimeLocation?: string;
+
+    /** The Runtime to Use*/
+    theRuntime?: string;
+
     /** Alternate GameMakerStudio2 Install Directory */
     gamemakerLocation?: string;
     /** Alternate GameMakerStudio2 ProgramData Directory */
@@ -66,6 +70,9 @@ export function compile(options: IRubberOptions) {
     const emitter = new EventEmitter() as RubberEventEmitter; // we dont need the overhead of a sub class
     const projectFile = resolve(options.projectPath);
     const platform = options.platform;
+
+    // Choose a specific runtime or use the active one if left blank
+    const theRuntime = options.theRuntime ? options.theRuntime : "";
 
     // Build component for checking later.
     let component = "";
@@ -114,7 +121,7 @@ export function compile(options: IRubberOptions) {
     }
 
     //Check target device name against the target device config file later
-    let targetDeviceName = options.targetDeviceName ? options.targetDeviceName:"";
+    let targetDeviceName = options.targetDeviceName ? options.targetDeviceName : "";
 
     // We want to run stuff async with await, so this will be in its own function.
     const asyncRun = async() => {
@@ -236,11 +243,21 @@ export function compile(options: IRubberOptions) {
                     throw new Error("Invalid GameMaker Studio 2 Runtime Index. Reinstall GameMaker.");
                 }
     
-                if (typeof runtimes.active !== "string") {
-                    throw new Error("GameMaker has no active runtime, start up GameMaker and compile a project first.");
+                if (theRuntime === ""){
+                    // Use the active runtime if user did not specify
+                    if (typeof runtimes.active !== "string") {
+                        throw new Error("GameMaker has no active runtime, start up GameMaker and compile a project first.");
+                    }                                        
+                    runtimeLocation = runtimes[runtimes.active];
                 }
-    
-                runtimeLocation = runtimes[runtimes.active];
+                else{
+                    if (runtimes[theRuntime]){
+                        runtimeLocation = runtimes[theRuntime];
+                    }
+                    else{
+                        throw new Error("Cannot find the chosen runtime. Make sure the input is correct and the runtime is downloaded.");                        
+                    }
+                }
                 runtimeLocation = runtimeLocation.substring(0, runtimeLocation.indexOf("&"));
             } else {
                 throw new Error("Cannot Locate GameMaker Studio 2 Runtimes. Either GameMaker is installed somewhere else, or is not been setup.");

--- a/src/rubber.ts
+++ b/src/rubber.ts
@@ -18,12 +18,14 @@ export interface IRubberOptions {
     /** Path to the .yyp file, this can be relative or absolute */
     projectPath: string;
 
-    /** Use YoYoCompiler instead of VM, default fase */
+    /** Use YoYoCompiler instead of VM, default false */
     yyc?: boolean;
     /** Set Debugger Port, default disable debugger */
     debug?: number;
     /** Enable Verbose on IGOR.exe, default false */
     verbose?: boolean;
+    /** Toggle whether to use the EA version */
+    ea?:boolean;
 
     /** Set GameMaker configuration, default "default" */
     config?: string;
@@ -145,11 +147,21 @@ export function compile(options: IRubberOptions) {
 
         // Fill in some defaults
         if (typeof options.gamemakerDataLocation === "undefined") {
-            options.gamemakerDataLocation = "C:\\ProgramData\\GameMakerStudio2";
+            if (options.ea){
+                options.gamemakerDataLocation = "C:\\ProgramData\\GameMakerStudio2-EA";
+            }
+            else{
+                options.gamemakerDataLocation = "C:\\ProgramData\\GameMakerStudio2";
+            }
         }
 
         if (typeof options.gamemakerLocation === "undefined" || options.gamemakerLocation === ""){
-            options.gamemakerLocation = "C:\\Program Files\\GameMaker Studio 2";
+            if (options.ea){
+                options.gamemakerLocation = "C:\\Program Files\\GameMaker Studio 2-EA";
+            }
+            else{
+                options.gamemakerLocation = "C:\\Program Files\\GameMaker Studio 2";
+            }            
         }
         else{
             if(!(await fse.pathExists(options.gamemakerLocation))) {
@@ -304,7 +316,7 @@ export function compile(options: IRubberOptions) {
         emitter.emit("compileStatus", "Creating Build Data\n");
         // a.
         const buildMeta: IBuildMeta = {
-            applicationPath: join(options.gamemakerLocation, "GameMakerStudio.exe"),
+            applicationPath: join(options.gamemakerLocation, options.ea ? "GameMakerStudio-EA.exe" : "GameMakerStudio.exe"),
             assetCompiler: "",
             compile_output_file_name: join(buildTempPath, "Output", projectName + ".win"),
             config: (options.config) ? options.config : "default",
@@ -375,9 +387,10 @@ export function compile(options: IRubberOptions) {
             "keytool_exe_path": "bin\\keytool.exe",
             "openssl_exe_path": "bin\\openssl.exe",
 
-            "program_dir_name": "GameMakerStudio2",
-            "program_name": "GameMakerStudio2",
-            "program_name_pretty": "GameMaker Studio 2",
+            "GMS_name": options.ea ? "GameMakerStudio2" : "GameMakerStudio2-EA",
+            "program_dir_name": "${GMS_name}",
+            "program_name": "${GMS_name}",
+            "program_name_pretty": "${GMS_name}",
 
             "default_font": "Open Sans",
             "default_style": "Regular",
@@ -391,7 +404,7 @@ export function compile(options: IRubberOptions) {
             "CommonProgramFilesX86": "C:\\Program Files (x86)\\Common Files",
             "UserProfile": "C:\\Users\\${UserProfileName}",
             "TempPath": "${UserProfile}\\AppData\\Local",
-            "exe_path": "${ProgramFiles}\\GameMaker Studio 2",
+            "exe_path": options.ea ? "${ProgramFiles}\\GameMaker Studio 2" : "${ProgramFiles}\\GameMaker Studio 2-EA",
         }
         await fse.writeFile(join(buildTempPath, "macros.json"), JSON.stringify(macros));
 


### PR DESCRIPTION
Added CLI option `--ea` and `--runtime`

The user can now use `--ea` if they are using the Early Access version of GMS, which has slightly different paths. 

The user can also use `--runtime` to specify the runtime if they want to rollback for some reason. Will choose the active runtime if left blank.