### PR TITLE
Add "scripts.prepare" and "files" fields to package.json (closes #15)

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,12 @@
 	"version": "2.4.0",
 	"description": "GMS2 project compilation",
 	"main": "out/rubber.js",
+	"scripts": {
+		"prepare": "./node_modules/typescript/bin/tsc"
+	},
+	"files":[
+		"/out"
+	],
 	"dependencies": {
 		"chalk": "^2.4.1",
 		"cli": "^1.0.1",


### PR DESCRIPTION
Taken together, these will guarantee that `npm publish` will result in the compiled code, and *only* the compiled code, will end up in npm. npm publish always includes project-descriptive files like package.json, license, etc.