### PR TITLE
fix: re-enabled `steam_options.yy` copying

### DIFF
--- a/src/rubber.ts
+++ b/src/rubber.ts
@@ -418,12 +418,12 @@ export function compile(options: IRubberOptions) {
         */
 
         // d.
-        /*
+        
         const steamOptions: IBuildSteamOptions = {
             steamsdk_path: await readLocalSetting("machine.Platform Settings.Steam.steamsdk_path"),
         };
         await fse.writeFile(join(buildTempPath, "steam_options.yy"), JSON.stringify(steamOptions));
-        */
+        
 
         // e.
         const targetoptions: IBuildTargetOptions = {


### PR DESCRIPTION
Turns out that this file does need to be copied to build with steam SDK. Otherwise, Igor gives the following error:

```
DoSteam
Options: C:\Users\xxx\AppData\Local\Temp\gamemaker-rubber\a6bd7537-1fad-4fbb-82ba-a6a2048a72c0\steam_options.yy
Failed to load Options from C:\Users\xxx\AppData\Local\Temp\gamemaker-rubber\a6bd7537-1fad-4fbb-82ba-a6a2048a72c0\steam_options.yy
Failed to copy Steam DLL - '' - SDK not installed properly? Check 'Preferences-Platform Settings-Steam-Path To Steam SDK'
```