### PR TITLE
feat: added the CLI command to use Igor to clear remote client

### DIFF
--- a/.vscode/.gitignore
+++ b/.vscode/.gitignore
@@ -1,0 +1,2 @@
+/tasks.json
+/settings.json

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -36,6 +36,7 @@ const options = cli.parse({
     config: ["c", "Sets the configuration", "string"],
     version: ["v", "Display the current version"],
     clear: ["", "Clears cache for project and exits."],
+    "clear_remote": ["","Clears the remote client cache."],
     "gms-dir":["","Alternative GMS installation directory","path"],
     "export-platform":["p","Export platform","string"],
     "device-config-dir":["","Target device config file directory", "path"],
@@ -79,14 +80,6 @@ cli.main(async (args, options) => {
         cli.fatal("Project invalid, or in a newer format. Exiting");
     }
 
-    // Clear cache option
-    if(options.clear) {
-        rubber.clearCache(path).then(() => {
-            cli.info("Cleared Project Cache.");
-        });
-        return;
-    }
-
     // We have a probably valid project. Time to pass it to rubber
     let buildType: "test" | "zip" | "installer" = "test";
     if (options.zip && options.installer) {
@@ -127,8 +120,8 @@ cli.main(async (args, options) => {
         theRuntime = options["runtime"];
     }
 
-    // Use the api to compile the project.
-    const build = rubber.compile({
+    //
+    let rubberOptions = {
         projectPath: path,
         build: buildType,
         outputPath: args[1] || "",
@@ -141,7 +134,19 @@ cli.main(async (args, options) => {
         targetDeviceName,
         theRuntime,
         ea: options.ea
-    });
+    }
+
+    // Clear build machine's cache
+    if(options.clear) {
+        rubber.clearCache(path).then(() => {
+            cli.info("Cleared Project Cache.");
+        });
+        return;
+    }
+
+    // Use the api to compile the project or clear the remote client cache.
+    const build = options["clear_remote"] ? rubber.clearCacheRemote(rubberOptions) : rubber.compile(rubberOptions,false);
+
     build.on("compileStatus", (data:string) => {
         // Errors will be marked in red
         if(data.toLowerCase().startsWith("error")) {

--- a/src/rubber.ts
+++ b/src/rubber.ts
@@ -68,8 +68,7 @@ export interface IRubberOptions {
  * @param projectFile Path to the .yyp project
  * @param options Object containing build information.
  */
-
-export function compile(options: IRubberOptions, clearRemoteCache: boolean) {
+export function compile(options: IRubberOptions, clearRemoteCache: boolean = false) {
     const emitter = new EventEmitter() as RubberEventEmitter; // we dont need the overhead of a sub class
     const projectFile = resolve(options.projectPath);
     const platform = options.platform;

--- a/src/rubber.ts
+++ b/src/rubber.ts
@@ -68,7 +68,8 @@ export interface IRubberOptions {
  * @param projectFile Path to the .yyp project
  * @param options Object containing build information.
  */
-export function compile(options: IRubberOptions) {
+
+export function compile(options: IRubberOptions, clearRemoteCache: boolean) {
     const emitter = new EventEmitter() as RubberEventEmitter; // we dont need the overhead of a sub class
     const projectFile = resolve(options.projectPath);
     const platform = options.platform;
@@ -506,7 +507,7 @@ export function compile(options: IRubberOptions) {
 
         emitter.emit("compileStatus", "Running IGOR\n");
         const exportType = options.build == "test" ? "Run" : (options.build === "zip" ? defaultPackageKey : "PackageNsis")
-        const igorArgs = ["-options=" + join(buildTempPath, "build.bff"), "--", component, exportType];
+        const igorArgs = ["-options=" + join(buildTempPath, "build.bff"), "--", component, clearRemoteCache ? "Clean" : exportType];
         const igor = spawn(join(runtimeLocation, "bin", "Igor.exe"), igorArgs);
     
         // !!! #8 todo: store errors here, emit at end.
@@ -585,4 +586,9 @@ export async function clearCache(projectPath: string) {
 
     // delete the folder
     await fse.remove(join(tempFolder, "gamemaker-rubber", guid));
+}
+
+/** Use Igor's Clean function to clear remote client's cache */
+export function clearCacheRemote(options: IRubberOptions){
+    return compile(options, true);
 }


### PR DESCRIPTION
When using remote client for iOS, Mac, and Linux, the remote clients' cache also need to be cleaned, or else the package made will contain garbage data. `Igor.exe` has a `Clean` command that achieves this, and it requires a lot of the files that `compile` already makes, so I made a wrapper function that hijacks the `compile` function.

It's not a good way to code, and the `Clean` command has some overlap with the existing `clearCache` function, so I will need to come back to this for refactoring.